### PR TITLE
Adjust arm lift max power and power at rest

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -70,9 +70,9 @@ public class HuskyBot {
 
     public static final double ARM_SWIVEL_MAX_POWER = 0.4;
     public static final double ARM_SWIVEL_LIMIT = 200;
-    public static final double ARM_LIFT_MAX_POWER = 0.25;
+    public static final double ARM_LIFT_MAX_POWER = 0.5;
     public static final double ARM_LIFT_MIN_POWER = 0.01;
-    public static final double ARM_LIFT_POWER_AT_REST = 0.05;
+    public static final double ARM_LIFT_POWER_AT_REST = 0.10;
     public static final double ARM_EXTENSION_MAX_POWER = 0.4;
 
     public static final double CLAW_MOVE_INCREMENT = 0.01;


### PR DESCRIPTION
* Increase arm max power based on testing. When the arm is extended, more power is needed so changed it from 0.25 to 0.5
* Increase arm power at rest. When the arm is extended or is holding a cone, it needs more power to stay fixed at a position. Increased to 0.05 to 0.10.
