### PR TITLE
Arm lift PIDF controller implementation

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -38,4 +38,5 @@ dependencies {
 
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'com.acmerobotics.roadrunner:core:0.5.6'
+    implementation 'org.ftclib.ftclib:core:2.0.1'
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -30,6 +30,9 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.roadrunner.profile.MotionProfile;
+import com.acmerobotics.roadrunner.profile.MotionProfileGenerator;
+import com.acmerobotics.roadrunner.profile.MotionState;
 import com.arcrobotics.ftclib.controller.PIDController;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
@@ -100,7 +103,7 @@ public class HuskyBot {
     public static final int ARM_SWIVEL_LEFT_LIMIT = 160;
 
     public static final int ARM_LIFT_MAX_POSITION = 910;
-    public static final int ARM_LIFT_MIN_POSITION = 0;
+    public static final int ARM_LIFT_MIN_POSITION = 20;
 
     public static final double CLAW_MOVE_INCREMENT = 0.05;
     public static final double CLAW_LIFT_MIN_RANGE = 0.0;
@@ -168,7 +171,7 @@ public class HuskyBot {
 
         // Set Drive Motor PIDF Coefficients
         // https://docs.google.com/document/u/1/d/1tyWrXDfMidwYyP_5H4mZyVgaEswhOC35gvdmP-V-5hA/mobilebasic
-        // todo these still need to be tuned
+        // to do these still need to be tuned
 //        frontLeftDrive.setVelocityPIDFCoefficients(1.82, 0.182, 0, 18.2);
 //        frontLeftDrive.setPositionPIDFCoefficients(5.0);
 //        rearLeftDrive.setVelocityPIDFCoefficients(1.18, 0.118, 0, 11.8);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -30,6 +30,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.acmerobotics.dashboard.config.Config;
+import com.arcrobotics.ftclib.controller.PIDController;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
@@ -62,7 +63,15 @@ public class HuskyBot {
     public DcMotorEx armLiftMotor = null;
     public DcMotorEx armExtendMotor = null;
 
-    // Claw (on the Arm) Servo Init.
+    // Arm Lift PID Controller Init.
+    public static final double up_Kp = 0.0055, up_Ki = 0, up_Kd = 0.00025;
+    public static final double down_Kp = 0.00025, down_Ki = 0, down_Kd = 0.000005;
+    public static PIDController armUpPID = new PIDController(up_Kp, up_Ki, up_Kd);
+    public static PIDController armDownPID = new PIDController(down_Kp, down_Ki, down_Kd);
+    public static final double f = 0.045, l = 0;
+    public static final double ARM_LIFT_TICKS_PER_DEGREE = 28.0 * 5.23 * 5.23 * 3.61 / 360;
+
+    // Claw Servo Init.
     public Servo clawLift = null;
     public Servo clawGrab = null;
 
@@ -91,6 +100,7 @@ public class HuskyBot {
     public static final int ARM_SWIVEL_LEFT_LIMIT = 160;
 
     public static final int ARM_LIFT_MAX_POSITION = 910;
+    public static final int ARM_LIFT_MIN_POSITION = 0;
 
     public static final double CLAW_MOVE_INCREMENT = 0.05;
     public static final double CLAW_LIFT_MIN_RANGE = 0.0;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyBot.java
@@ -68,7 +68,7 @@ public class HuskyBot {
 
     // Arm Lift PID Controller Init.
     public static final double up_Kp = 0.0055, up_Ki = 0, up_Kd = 0.00025;
-    public static final double down_Kp = 0.00025, down_Ki = 0, down_Kd = 0.000005;
+    public static final double down_Kp = 0.00038, down_Ki = 0, down_Kd = 0.00001;
     public static PIDController armUpPID = new PIDController(up_Kp, up_Ki, up_Kd);
     public static PIDController armDownPID = new PIDController(down_Kp, down_Ki, down_Kd);
     public static final double f = 0.045, l = 0;
@@ -105,7 +105,7 @@ public class HuskyBot {
     public static final int ARM_LIFT_MAX_POSITION = 910;
     public static final int ARM_LIFT_MIN_POSITION = 20;
 
-    public static final double CLAW_MOVE_INCREMENT = 0.05;
+    public static final double CLAW_MOVE_INCREMENT = 0.025;
     public static final double CLAW_LIFT_MIN_RANGE = 0.0;
     public static final double CLAW_LIFT_MAX_RANGE = 1.0;
     public static final double CLAW_LIFT_START_POSITION = 0.6;   // scaled, see MIN and MAX_RANGE

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -67,6 +67,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
         STEP_4
     }
     ArmState armState = ArmState.ARM_WAIT;
+    int follow_point = ARM_LIFT_MIN_POSITION;
 
     int armLiftTargetPos = 0;
     int armExtendTargetPos;
@@ -310,6 +311,8 @@ public class HuskyTeleOpMode extends LinearOpMode {
                         huskyBot.armExtendMotor.setPower(0);
                         huskyBot.armExtendMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
 
+                        follow_point = huskyBot.armLiftMotor.getCurrentPosition();
+
                         armState = ArmState.STEP_3;
                     }
 
@@ -318,7 +321,17 @@ public class HuskyTeleOpMode extends LinearOpMode {
                     // Step 3:
                     // Wait until the step 2 is completed
                     // Then change the arm extender's position (in or out based on the target position)
-                    armLiftRunToPos(armLiftTargetPos);
+
+                    // Gradually increment follow_point until it reaches the target position.
+                    int error = follow_point - armLiftTargetPos;
+                    if (error > 30) {
+                        follow_point -= 30;
+                    } else if (error < 30) {
+                        follow_point += 30;
+                    } else {
+                        follow_point = armLiftTargetPos;
+                    }
+                    armLiftRunToPos(follow_point);
 
                     if (Math.abs(huskyBot.armLiftMotor.getCurrentPosition() - armLiftTargetPos) > 100) {
                         if(finiteTimer.seconds() > 7){
@@ -401,6 +414,12 @@ public class HuskyTeleOpMode extends LinearOpMode {
             // Claw Telemetry
             telemetry.addData("Claw Lift", "Right Y: (%.2f), Pos: (%.2f)",gamepad2.right_stick_y, huskyBot.clawLift.getPosition());
             telemetry.addData("Claw Grab", "Pos: (%.2f)", huskyBot.clawGrab.getPosition());
+
+            telemetry.addData("current pos ", huskyBot.armLiftMotor.getCurrentPosition());
+            telemetry.addData("target pos ", armLiftTargetPos);
+            telemetry.addData("follow point ", follow_point);
+            telemetry.addData("vel ", huskyBot.armLiftMotor.getVelocity());
+
             telemetry.update();
         // endregion
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -78,9 +78,9 @@ public class HuskyTeleOpMode extends LinearOpMode {
 
     private PIDController armUpPID;
     private PIDController armDownPID;
-    public static double up_Kp = 0, up_Ki = 0, up_Kd = 0;
-    public static double down_Kp = 0, down_Ki = 0, down_Kd = 0;
-    public static double f = 0, l = 0;
+    public static double up_Kp = 0.0055, up_Ki = 0, up_Kd = 0.00025;
+    public static double down_Kp = 0.00025, down_Ki = 0, down_Kd = 0.000005;
+    public static double f = 0.045, l = 0;
     public static int target = 0;
 
     private final double ARM_LIFT_TICKS_PER_DEGREE = 28.0 * 5.23 * 5.23 * 3.61 / 360;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -324,10 +324,10 @@ public class HuskyTeleOpMode extends LinearOpMode {
 
                     // Gradually increment follow_point until it reaches the target position.
                     int error = follow_point - armLiftTargetPos;
-                    if (error > 30) {
-                        follow_point -= 30;
-                    } else if (error < 30) {
-                        follow_point += 30;
+                    if (error > 50) {
+                        follow_point -= 50;
+                    } else if (error < 50) {
+                        follow_point += 50;
                     } else {
                         follow_point = armLiftTargetPos;
                     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -224,8 +224,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
                 huskyBot.armExtendMotor.setPower(0);
                 huskyBot.armExtendMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
 
-                huskyBot.armLiftMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
-                huskyBot.armLiftMotor.setPower(ARM_LIFT_POWER_AT_REST);
+                armLiftTargetPos = huskyBot.armLiftMotor.getCurrentPosition();
 
                 armState = ArmState.ARM_WAIT;
             }
@@ -291,6 +290,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
                     // Step 2:
                     // Wait until the step 1 is completed
                     // Then change the arm lift's position (up or down based on the target position)
+                    armLiftRunToPos(huskyBot.armLiftMotor.getCurrentPosition());
 
                     if(huskyBot.armExtendMotor.isBusy()){
                         if(finiteTimer.seconds() > 7){
@@ -298,6 +298,8 @@ public class HuskyTeleOpMode extends LinearOpMode {
 
                             huskyBot.armExtendMotor.setPower(0);
                             huskyBot.armExtendMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+
+                            armLiftTargetPos = huskyBot.armLiftMotor.getCurrentPosition();
 
                             armState = ArmState.ARM_WAIT;
                             break;
@@ -308,10 +310,6 @@ public class HuskyTeleOpMode extends LinearOpMode {
                         huskyBot.armExtendMotor.setPower(0);
                         huskyBot.armExtendMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
 
-                        huskyBot.armLiftMotor.setTargetPosition(armLiftTargetPos);
-                        huskyBot.armLiftMotor.setPower(0.35);
-                        huskyBot.armLiftMotor.setMode(DcMotor.RunMode.RUN_TO_POSITION);
-
                         armState = ArmState.STEP_3;
                     }
 
@@ -320,13 +318,13 @@ public class HuskyTeleOpMode extends LinearOpMode {
                     // Step 3:
                     // Wait until the step 2 is completed
                     // Then change the arm extender's position (in or out based on the target position)
+                    armLiftRunToPos(armLiftTargetPos);
 
-                    if (huskyBot.armLiftMotor.isBusy()) {
+                    if (Math.abs(huskyBot.armLiftMotor.getCurrentPosition() - armLiftTargetPos) > 100) {
                         if(finiteTimer.seconds() > 7){
                             gamepad1.rumble(1000);
 
-                            huskyBot.armLiftMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
-                            huskyBot.armLiftMotor.setPower(ARM_LIFT_POWER_AT_REST);
+                            armLiftTargetPos = huskyBot.armLiftMotor.getCurrentPosition();
 
                             armState = ArmState.ARM_WAIT;
                             break;
@@ -334,9 +332,6 @@ public class HuskyTeleOpMode extends LinearOpMode {
 
                         telemetry.addData("Arm State Status", "Arm lift is moving");
                     } else {
-                        huskyBot.armLiftMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
-                        huskyBot.armLiftMotor.setPower(ARM_LIFT_POWER_AT_REST);
-
                         huskyBot.armExtendMotor.setTargetPosition(armExtendTargetPos);
                         huskyBot.armExtendMotor.setPower(1.0);
                         huskyBot.armExtendMotor.setMode(DcMotor.RunMode.RUN_TO_POSITION);
@@ -350,6 +345,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
                     // Step 4:
                     // Wait until the step 3 is completed
                     // Then change armState to wait (default)
+                    armLiftRunToPos(armLiftTargetPos);
 
                     if (huskyBot.armExtendMotor.isBusy()) {
                         if(finiteTimer.seconds() > 7){
@@ -357,6 +353,8 @@ public class HuskyTeleOpMode extends LinearOpMode {
 
                             huskyBot.armExtendMotor.setPower(0);
                             huskyBot.armExtendMotor.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+
+                            armLiftTargetPos = huskyBot.armLiftMotor.getCurrentPosition();
 
                             armState = ArmState.ARM_WAIT;
                             break;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/HuskyTeleOpMode.java
@@ -31,9 +31,12 @@ package org.firstinspires.ftc.teamcode;
 
 import static org.firstinspires.ftc.teamcode.HuskyBot.*;
 
+import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.acmerobotics.roadrunner.geometry.Vector2d;
+import com.arcrobotics.ftclib.controller.PIDController;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.DcMotor;
@@ -53,12 +56,9 @@ public class HuskyTeleOpMode extends LinearOpMode {
     boolean endGameRumbled = false;
     boolean finalRumbled = false;
 
-    double x, y, rx;
-
     double armSwivelPower = 0.0;
     double armExtendPower = 0.0;
     double armLiftPower = 0.0;
-    double armLiftPowerDivider = 4;
 
     private ElapsedTime finiteTimer = new ElapsedTime();
     public enum ArmState {
@@ -75,6 +75,13 @@ public class HuskyTeleOpMode extends LinearOpMode {
     double clawLiftTargetPos;
     boolean shouldChangeTheClawLift = false;
     // endregion
+
+    private PIDController armController;
+    public static double p = 0, i = 0, d = 0;
+    public static double f = 0, l = 0;
+    public static int target = 0;
+
+    private final double ARM_LIFT_TICKS_PER_DEGREE = 28.0 * 5.23 * 5.23 * 3.61 / 360;
 
     // region DEFINE FUNCTIONS
     // method to smoothly accelerate a motor given a target velocity.
@@ -107,8 +114,8 @@ public class HuskyTeleOpMode extends LinearOpMode {
         huskyBot.init(hardwareMap);
         huskyBot.drive.setPoseEstimate(new Pose2d(0, 0, Math.toRadians(0)));
 
-        telemetry.addData("Status", "Initialized");
-        telemetry.update();
+//        telemetry.addData("Status", "Initialized");
+//        telemetry.update();
 
         waitForStart();
         runtime.reset();
@@ -116,6 +123,8 @@ public class HuskyTeleOpMode extends LinearOpMode {
         huskyBot.clawLift.setPosition(CLAW_LIFT_START_POSITION);
         huskyBot.clawGrab.setPosition(CLAW_GRAB_CLOSE_POSITION);
         // endregion
+        armController = new PIDController(p, i, d);
+        telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
 
         // region TELE-OP LOOP
         while (opModeIsActive()) {
@@ -160,23 +169,24 @@ public class HuskyTeleOpMode extends LinearOpMode {
             // region Blocked by Preset FSM
             if (armState == ArmState.ARM_WAIT) {
                 // Arm Lift Controls
-                if (gamepad2.left_stick_y < 0) {
-                    // on the way up
-                    armLiftPowerDivider = 3.5 - ((double) huskyBot.armLiftMotor.getCurrentPosition() / ARM_LIFT_MAX_POSITION);
-                } else { // on the way down
-                    armLiftPowerDivider = 5.5;
-                }
+                armController.setPID(p, i, d);
 
-                armLiftPower = -gamepad2.left_stick_y / armLiftPowerDivider;
-                armLiftPower = Range.clip(armLiftPower, -ARM_LIFT_MIN_POWER, ARM_LIFT_MAX_POWER);
+                int armPos = huskyBot.armLiftMotor.getCurrentPosition();
+                int extendPos = huskyBot.armExtendMotor.getCurrentPosition();
 
-                if (armLiftPower == 0) {
-                    armLiftPower = ARM_LIFT_POWER_AT_REST;
-                }
-                if (huskyBot.armLiftMotor.getCurrentPosition() > ARM_LIFT_MAX_POSITION && armLiftPower > 0) {
-                    armLiftPower = 0;
-                }
+                double targetArmAngle = Math.cos(Math.toRadians((target - 470) / ARM_LIFT_TICKS_PER_DEGREE));
+
+                double pid = armController.calculate(armPos, target);
+                double ff = (l * extendPos + 1) * f * targetArmAngle;
+
+                armLiftPower = pid + ff;
                 huskyBot.armLiftMotor.setPower(armLiftPower);
+
+                telemetry.addData("extend ", extendPos);
+                telemetry.addData("target angle ", targetArmAngle);
+                telemetry.addData("pos ", armPos);
+                telemetry.addData("target ", target);
+                telemetry.update();
 
 
                 // Increases/Decreases Arm Length
@@ -389,7 +399,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
             }
         // endregion
 
-
+/*
         // region TELEMETRY
             telemetry.addData("Status", "Run Time: " + runtime.toString());
             telemetry.addData("Stick", "y (%.2f), x (%.2f), rx (%.2f)", y, x, rx);
@@ -414,7 +424,7 @@ public class HuskyTeleOpMode extends LinearOpMode {
             telemetry.addData("Arm Lift Power Divider", armLiftPowerDivider);
             telemetry.update();
         // endregion
-
+*/
         }
         // endregion
 

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -21,7 +21,7 @@ apply plugin: 'com.android.application'
 
 android {
 
-    compileSdkVersion 29
+    compileSdkVersion 33
 
     signingConfigs {
         release {
@@ -51,7 +51,7 @@ android {
     defaultConfig {
         signingConfig signingConfigs.debug
         applicationId 'com.qualcomm.ftcrobotcontroller'
-        minSdkVersion 23
+        minSdkVersion 24
         //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 28
 
@@ -67,7 +67,7 @@ android {
          * @see <a href="http://developer.android.com/tools/building/configuring-gradle.html">Configure Your Build</a>
          * @see <a href="http://developer.android.com/tools/publishing/versioning.html">Versioning Your App</a>
          */
-        def manifestFile = project(':FtcRobotController').file('src/main/AndroidManifest.xml');
+        def manifestFile = project(':FtcRobotController').file('src/main/AndroidManifest.xml')
         def manifestText = manifestFile.getText()
         //
         def vCodePattern = Pattern.compile("versionCode=\"(\\d+(\\.\\d+)*)\"")
@@ -76,7 +76,7 @@ android {
         def vCode = Integer.parseInt(matcher.group(1))
         //
         def vNamePattern = Pattern.compile("versionName=\"(.*)\"")
-        matcher = vNamePattern.matcher(manifestText);
+        matcher = vNamePattern.matcher(manifestText)
         matcher.find()
         def vName = matcher.group(1)
         //
@@ -119,4 +119,5 @@ repositories {
     flatDir {
         dirs rootProject.file('libs')
     }
+    mavenCentral()
 }

--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation 'org.firstinspires.ftc:Hardware:8.1.1'
     implementation 'org.firstinspires.ftc:FtcCommon:8.1.1'
     implementation 'org.tensorflow:tensorflow-lite-task-vision:0.2.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
     implementation 'org.firstinspires.ftc:gameAssets-PowerPlay:1.0.0'
-    implementation 'com.acmerobotics.dashboard:dashboard:0.4.5'
+    implementation 'com.acmerobotics.dashboard:dashboard:0.4.7'
 }


### PR DESCRIPTION
This PR contains the implementation of custom PID controllers to control the position of the arm. Since the arm is a nonlinear system, we used gain scheduling (switching between 2 PID controllers depending on if the arm is moving up or down) to get consistent movement in both directions.

The new implementations for arm movement have been tested, both for manual and preset arm lift control. Both are stable and behave as expected. Attempting to switch between both does not cause any glitches.